### PR TITLE
Added cython as a "setup_requires" dependency to facilitate the installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
-from Cython.Build import cythonize
 from setuptools.extension import Extension
 from setuptools import setup, find_packages
 
-extensions = cythonize([Extension("quicksect", ["src/quicksect.pyx"])])
+extensions = [Extension("quicksect", ["src/quicksect.pyx"])]
 
 setup(version='0.0.2',
 	  name='quicksect',
@@ -11,7 +10,8 @@ setup(version='0.0.2',
       author="Brent Pedersen",
       author_email="bpederse@gmail.com",
       packages=find_packages(),
-      ext_modules=cythonize(extensions),
+      setup_requires=['cython'],
+      ext_modules=extensions,
       test_suite='nose.collector',
       tests_require='nose',
 )


### PR DESCRIPTION
The README claims that one can do ```pip install quicksect``` but that requires `cython` to be installed, e.g.
```
$ pip install quicksect
Downloading/unpacking quicksect
  Downloading quicksect-0.0.2.tar.gz (61kB): 61kB downloaded
  Running setup.py (path:/home/matthieu/src/local/virtualenv/tmp_quick4/build/quicksect/setup.py) egg_info for package quicksect
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/home/matthieu/src/local/virtualenv/tmp_quick4/build/quicksect/setup.py", line 1, in <module>
        from Cython.Build import cythonize
    ImportError: No module named Cython.Build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/home/matthieu/src/local/virtualenv/tmp_quick4/build/quicksect/setup.py", line 1, in <module>

    from Cython.Build import cythonize

ImportError: No module named Cython.Build

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /home/matthieu/src/local/virtualenv/tmp_quick4/build/quicksect
Storing debug log for failure in /home/matthieu/.pip/pip.log
```

With this change, `cython` is transparently pulled for the build stage and one can _really_ use `pip install quicksect`